### PR TITLE
Register interest form link and content

### DIFF
--- a/interactive/templates/index.html
+++ b/interactive/templates/index.html
@@ -28,7 +28,8 @@ for NHS electronic health records{% endblock meta_title %}
                     {% include "components/button.html" with el="link" size="lg" color="oxford" text="Log in" href=login_url %}
                   </li>
                   <li class="ml-3 inline-flex">
-                    {% include "components/button.html" with el="link" size="lg" color="oxford-100" text="Request access" href="#" %}
+                    {% url 'register_interest' as register_interest_url %}
+                    {% include "components/button.html" with el="link" size="lg" color="oxford-100" text="Register your interest" href=register_interest_url %}
                   </li>
                 {% endif %}
               </ul>
@@ -125,7 +126,8 @@ for NHS electronic health records{% endblock meta_title %}
                   {% include "components/button.html" with el="link" size="lg" color="oxford-50" text="Log in" href=login_url %}
                 </li>
                 <li class="ml-3 inline-flex">
-                  {% include "components/button.html" with el="link" size="lg" color="oxford-50" text="Request access" href="#" %}
+                  {% url 'register_interest' as register_interest_url %}
+                  {% include "components/button.html" with el="link" size="lg" color="oxford-50" text="Register your interst" href=register_interest_url %}
                 </li>
               {% endif %}
             </ul>

--- a/interactive/templates/index.html
+++ b/interactive/templates/index.html
@@ -17,6 +17,7 @@ for NHS electronic health records{% endblock meta_title %}
                 <span class="md:block text-oxford-300">for NHS electronic health records</span>
               </h1>
               <p class="mt-3 text-base text-oxford-50 sm:mt-5 sm:text-xl lg:text-lg xl:text-xl">Securely delivering research across over 58 million people's health records, always respecting patient confidentiality.</p>
+              <p class="mt-3 text-base text-oxford-50 sm:mt-5 sm:text-xl lg:text-lg xl:text-xl">OpenSAFELY Interactive is a new service in development to offer analysis of patient records via simple point-and-click tools.</p>
               <ul class="mt-8 flex sm:justify-center lg:justify-start">
                 {% if user.is_authenticated %}
                   <li class="inline-flex rounded-md shadow">

--- a/interactive/templates/index.html
+++ b/interactive/templates/index.html
@@ -127,7 +127,7 @@ for NHS electronic health records{% endblock meta_title %}
                 </li>
                 <li class="ml-3 inline-flex">
                   {% url 'register_interest' as register_interest_url %}
-                  {% include "components/button.html" with el="link" size="lg" color="oxford-50" text="Register your interst" href=register_interest_url %}
+                  {% include "components/button.html" with el="link" size="lg" color="oxford-50" text="Register your interest" href=register_interest_url %}
                 </li>
               {% endif %}
             </ul>

--- a/interactive/templates/index.html
+++ b/interactive/templates/index.html
@@ -46,7 +46,7 @@ for NHS electronic health records{% endblock meta_title %}
   </section>
 
   {# Features section #}
-  <section class="hidden bg-white" aria-labelledby="featuresHeading">
+  <section class="bg-white" aria-labelledby="featuresHeading">
     <div class="container py-16 px-4 sm:px-6 lg:py-24 lg:px-8">
       <div class="max-w-3xl mx-auto text-center">
         <h2 class="text-3xl font-extrabold text-slate-900" id="featuresHeading">All-in-one platform</h2>
@@ -106,7 +106,7 @@ for NHS electronic health records{% endblock meta_title %}
   </section>
 
   {# CTA section #}
-  <section class="hidden bg-white" aria-labelledby="ctaHeading">
+  <section class="bg-white" aria-labelledby="ctaHeading">
     <div class="container py-16 px-4 sm:px-6 lg:px-8">
       <div class="bg-oxford-700 rounded-lg shadow-xl overflow-hidden lg:grid lg:grid-cols-2 lg:gap-4">
         <div class="pt-10 pb-12 px-6 sm:pt-16 sm:px-16 lg:py-16 lg:pr-0 xl:py-20 xl:px-20">

--- a/interactive/templates/partials/banner.html
+++ b/interactive/templates/partials/banner.html
@@ -10,7 +10,7 @@
   <div class="max-w-7xl mx-auto py-3 px-3 sm:px-6 lg:px-8">
     <div class="pr-16 sm:text-center sm:px-16">
       <p class="font-medium text-amber-800">
-        OpenSAFELY Interactive is under construction. You should not use this site unless the OpenSAFELY team have contacted you.
+        OpenSAFELY Interactive is under construction. 
       </p>
     </div>
     <div class="absolute inset-y-0 right-0 pt-1 pr-1 flex items-start sm:pt-1 sm:pr-2 sm:items-start">

--- a/interactive/urls.py
+++ b/interactive/urls.py
@@ -56,6 +56,13 @@ urlpatterns = [
     ),
     path("favicon.ico", RedirectView.as_view(url=settings.STATIC_URL + "favicon.ico")),
     path("robots.txt", RedirectView.as_view(url=settings.STATIC_URL + "robots.txt")),
+    path(
+        "register-interest/",
+        RedirectView.as_view(
+            url="https://docs.google.com/forms/d/e/1FAIpQLScuaBMu6LdVZaDml1KvcVLmSDvOGCUaPTnDtbL_4UdeW-F6Hw/viewform?usp=sf_link"
+        ),
+        name="register_interest",
+    ),
 ]
 
 handler400 = views.bad_request


### PR DESCRIPTION
🚧 WIP

- Update homepage buttons to point to `/register-interest/`
- Redirect `register-interest/` to Google Form
- Show content on the home page (revert https://github.com/opensafely-core/interactive.opensafely.org/pull/58/commits/ad525c3aae1c9984ad3cb8dc6ee9786f44fb58bb to hide content again)