### PR TITLE
Retrieve files from job server

### DIFF
--- a/dotenv-sample
+++ b/dotenv-sample
@@ -22,6 +22,9 @@ SLACK_BOT_TOKEN=fake_token
 # URL to run jobs manually on job-server, used for the slack notification
 JOB_SERVER_JOBS_URL=https://jobs.opensafely.org/datalab/opensafely-interactive/opensafely-interactive/run-jobs/
 
+# Retrieve outputs from job-server
+JOB_SERVER_API=https://jobs.opensafely.org/
+JOB_SERVER_TOKEN=fake_token
 
 # git config
 # repo to commit to, defaults to local test repo

--- a/interactive/settings.py
+++ b/interactive/settings.py
@@ -53,6 +53,7 @@ INSTALLED_APPS = [
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
+    "django.contrib.humanize",
     "django.contrib.sessions",
     "django.contrib.messages",
 ]

--- a/interactive/templates/interactive/analysis_request_output.html
+++ b/interactive/templates/interactive/analysis_request_output.html
@@ -1,5 +1,7 @@
 {% extends "interactive/template.html" %}
 
+{% load humanize %}
+
 {% block meta_title %}Analysis Output | OpenSAFELY Interactive{% endblock meta_title %}
 
 {% block template_heading %}
@@ -23,15 +25,15 @@
     <table>
       <tr>
         <th>Total events</th>
-        <td>...</td>
+        <td>{{ summary.0.count|intcomma }}</td>
       </tr>
       <tr>
         <th>Events in latest period</th>
-        <td>...</td>
+        <td>{{ summary.1.count|intcomma }}</td>
       </tr>
       <tr>
         <th>Unique patients</th>
-        <td>...</td>
+        <td>{{ summary.2.count|intcomma }}</td>
       </tr>
     </table>
   </div>
@@ -39,7 +41,7 @@
 <div class="mt-12 text-slate-800">
   <div class="prose prose-oxford">
     <figure>The rate of recording per 1000 across practices</figure>
-    <p>--Deciles chart--</p>
+    <img src="data:image;base64,{{ deciles_chart }}" />
   </div>
 </div>
 <div class="mt-12 text-slate-800">
@@ -47,7 +49,13 @@
     <h3>Most common codes (<a href="https://www.opencodelists.org/codelist/{{ analysis.codelist }}">Codelist</a>)</h3>
     <table>
       <thead><th>Code</th><th>Description</th><th>Proportion of codes (%)</th></thead>
-      <tbody><td>...</td><td>...</td><td>...</td></tbody>
+      {% for code in common_codes %}
+        <tbody>
+          <td>{{ code.Code }}</td>
+          <td>{{ code.Description }}</td>
+          <td>{{ code.Proportion }}</td>
+        </tbody>
+      {% endfor %}
     </table>
   </div>
 </div>

--- a/interactive/templates/interactive/analysis_request_output.html
+++ b/interactive/templates/interactive/analysis_request_output.html
@@ -15,12 +15,12 @@
   <div class="prose prose-oxford">
     <h2>{{ analysis.title }}</h2>
     <p>The aim of this OpenSAFELY Interactive report is to describe trends and variation in clinical codes to inform further analyses. It is not intended to be a tool for "performance monitoring".</p>
-    <p>Sharing outside of NHS England is not permitted in the current pilot phase without further approvals. Please contact xx if you would like to seek approval for wider sharing.</p>
+    <p>Sharing outside of NHS England is not permitted in the current pilot phase without further approvals. Please contact {% include "components/link.html" with href="mailto:team@opensafely.org" content="The OpenSAFELY Team" %} if you would like to seek approval for wider sharing.</p>
   </div>
 </div>
 <div class="mt-12 text-slate-800">
   <div class="prose prose-oxford">
-    <p>Requested codelist: <a href="https://www.opencodelists.org/codelist/{{ analysis.codelist }}">{{ analysis.codelist }}</a></p>
+    <p>Requested codelist: <a class="text-oxford-600 font-semibold underline underline-offset-1 transition-colors hover:text-oxford-500 hover:no-underline focus:text-oxford-700 focus:no-underline" href="https://www.opencodelists.org/codelist/{{ analysis.codelist }}">{{ analysis.codelist }}</a></p>
     <p>Time period: {{ analysis.start_date }} and {{ analysis.end_date }}</p>
     <table>
       <tr>
@@ -46,7 +46,7 @@
 </div>
 <div class="mt-12 text-slate-800">
   <div class="prose prose-oxford">
-    <h3>Most common codes (<a href="https://www.opencodelists.org/codelist/{{ analysis.codelist }}">Codelist</a>)</h3>
+    <h3>Most common codes (<a class="text-oxford-600 font-semibold underline underline-offset-1 transition-colors hover:text-oxford-500 hover:no-underline focus:text-oxford-700 focus:no-underline" href="https://www.opencodelists.org/codelist/{{ analysis.codelist }}">Codelist</a>)</h3>
     <table>
       <thead><th>Code</th><th>Description</th><th>Proportion of codes (%)</th></thead>
       {% for code in common_codes %}

--- a/interactive/templates/interactive/analysis_request_output.html
+++ b/interactive/templates/interactive/analysis_request_output.html
@@ -14,8 +14,8 @@
 <div class="text-center text-slate-800">
   <div class="prose prose-oxford">
     <h2>{{ analysis.title }}</h2>
+    <p class="font-semibold text-red-800">Sharing outside of NHS England is not permitted in the current pilot phase without further approvals. Please contact {% include "components/link.html" with href="mailto:team@opensafely.org" content="The OpenSAFELY Team" %} if you would like to seek approval for wider sharing.</p>
     <p>The aim of this OpenSAFELY Interactive report is to describe trends and variation in clinical codes to inform further analyses. It is not intended to be a tool for "performance monitoring".</p>
-    <p>Sharing outside of NHS England is not permitted in the current pilot phase without further approvals. Please contact {% include "components/link.html" with href="mailto:team@opensafely.org" content="The OpenSAFELY Team" %} if you would like to seek approval for wider sharing.</p>
   </div>
 </div>
 <div class="mt-12 text-slate-800">

--- a/interactive/templates/interactive/analysis_request_output.html
+++ b/interactive/templates/interactive/analysis_request_output.html
@@ -1,4 +1,4 @@
-{% extends "interactive/template.html" %}
+{% extends "interactive/output_template.html" %}
 
 {% load humanize %}
 

--- a/interactive/templates/interactive/output_template.html
+++ b/interactive/templates/interactive/output_template.html
@@ -1,0 +1,16 @@
+{% extends "base.html" %}
+
+{% block html_class %}h-full bg-slate-50{% endblock html_class %}
+{% block body_class %}h-full{% endblock body_class %}
+
+{% block content %}
+<div class="flex flex-col justify-center py-12 sm:px-6 lg:px-8">
+  <div class="flex flex-col mb-6 sm:mx-auto">
+    {% block template_heading %}{% endblock template_heading %}
+  </div>
+
+  <div class="bg-white sm:mx-auto py-8 px-4 shadow sm:rounded-lg sm:px-10">
+    {% block template_content %}{% endblock template_content %}
+  </div>
+</div>
+{% endblock %}

--- a/interactive/views.py
+++ b/interactive/views.py
@@ -6,7 +6,7 @@ from django.core.exceptions import PermissionDenied
 from django.shortcuts import redirect, render
 
 from interactive.submit import submit_analysis
-from services import opencodelists
+from services import jobserver, opencodelists
 
 from .forms import AnalysisRequestForm, RegistrationRequestForm
 from .models import END_DATE, START_DATE, AnalysisRequest
@@ -69,10 +69,14 @@ def analysis_request_output(request, pk):
     if not analysis_request.visible_to(request.user):
         raise PermissionDenied
 
+    context = {"analysis": analysis_request}
+    if outputs := jobserver.fetch_release(str(analysis_request.id.uuid)):
+        context.update(outputs)
+
     return render(
         request,
         "interactive/analysis_request_output.html",
-        {"analysis": analysis_request},
+        context,
     )
 
 

--- a/services/jobserver.py
+++ b/services/jobserver.py
@@ -1,0 +1,90 @@
+import csv
+from base64 import b64encode
+from urllib.parse import urljoin
+
+from environs import Env
+
+from services import session
+
+
+env = Env()
+
+JOB_SERVER_URL = env.str("JOB_SERVER_API")
+JOB_SERVER_TOKEN = env.str("JOB_SERVER_TOKEN")
+RELEASES_URL = urljoin(
+    JOB_SERVER_URL,
+    "api/v2/releases/workspace/test-interactive",
+)
+
+
+def fetch_release(analysis_request_id):
+    headers = {"Authorization": JOB_SERVER_TOKEN}
+    response = session.get(
+        RELEASES_URL,
+        headers=headers,
+    )
+    response.raise_for_status()
+
+    output = {}
+    for file in response.json()["files"]:
+        if DecilesChart.exists(file, analysis_request_id):
+            output[DecilesChart.name] = DecilesChart.decode(file)
+        elif EventsCount.exists(file, analysis_request_id):
+            output[EventsCount.name] = EventsCount.decode(file)
+        elif CommonCodes.exists(file, analysis_request_id):  # pragma: no cover
+            output[CommonCodes.name] = CommonCodes.decode(file)
+
+    return output
+
+
+def fetch_file(url):
+    headers = {"Authorization": JOB_SERVER_TOKEN}
+    response = session.get(urljoin(JOB_SERVER_URL, url), headers=headers)
+    response.raise_for_status()
+
+    return response.content
+
+
+class DecilesChart:
+    name = "deciles_chart"
+
+    def exists(file, analysis_request_id):
+        return analysis_request_id in file["name"] and file["name"].endswith(
+            "deciles_chart_counts_per_week_per_practice.png"
+        )
+
+    def decode(file):
+        return b64encode(fetch_file(file["url"])).decode("utf-8")
+
+
+class EventsCount:
+    name = "summary"
+
+    def exists(file, analysis_request_id):
+        return analysis_request_id in file["name"] and file["name"].endswith(
+            "event_counts.csv"
+        )
+
+    def decode(file):
+        return EventsCount.read_event_counts(fetch_file(file["url"]))
+
+    def read_event_counts(file):
+        return list(csv.DictReader(file.decode("utf-8").splitlines()))
+
+
+class CommonCodes:
+    name = "common_codes"
+
+    def exists(file, analysis_request_id):
+        return analysis_request_id in file["name"] and file["name"].endswith(
+            "top_5_code_table.csv"
+        )
+
+    def decode(file):
+        return CommonCodes.read_common_codes(fetch_file(file["url"]))
+
+    def read_common_codes(file):
+        common_codes = list(csv.DictReader(file.decode("utf-8").splitlines()))
+        for line in common_codes:
+            line["Proportion"] = line["Proportion of codes (%)"]
+        return common_codes

--- a/services/jobserver.py
+++ b/services/jobserver.py
@@ -86,5 +86,5 @@ class CommonCodes:
     def read_common_codes(file):
         common_codes = list(csv.DictReader(file.decode("utf-8").splitlines()))
         for line in common_codes:
-            line["Proportion"] = line["Proportion of codes (%)"]
+            line["Proportion"] = line.get("Proportion of codes (%)")
         return common_codes

--- a/services/jobserver.py
+++ b/services/jobserver.py
@@ -26,13 +26,11 @@ def fetch_release(analysis_request_id):
     response.raise_for_status()
 
     output = {}
+    file_types = [DecilesChart, EventsCount, CommonCodes]
     for file in response.json()["files"]:
-        if DecilesChart.exists(file, analysis_request_id):
-            output[DecilesChart.name] = DecilesChart.decode(file)
-        elif EventsCount.exists(file, analysis_request_id):
-            output[EventsCount.name] = EventsCount.decode(file)
-        elif CommonCodes.exists(file, analysis_request_id):  # pragma: no cover
-            output[CommonCodes.name] = CommonCodes.decode(file)
+        for file_type in file_types:
+            if file_type.exists(file, analysis_request_id):
+                output[file_type.name] = file_type.decode(file)
 
     return output
 

--- a/tests/unit/services/test_jobserver.py
+++ b/tests/unit/services/test_jobserver.py
@@ -1,0 +1,74 @@
+from urllib.parse import urljoin
+
+import pytest
+import requests
+
+from services import jobserver
+
+
+@pytest.fixture
+def fetch_release(responses):
+    responses.add(
+        method="GET",
+        url=jobserver.RELEASES_URL,
+        json={
+            "files": [
+                {
+                    "name": "backend/output/123/deciles_chart_counts_per_week_per_practice.png",
+                    "url": "/api/v2/releases/file/6STFP07F15EM",
+                },
+                {
+                    "name": "backend/output/123/event_counts.csv",
+                    "url": "/api/v2/releases/file/EK8NRG9A6GKQGJ",
+                },
+                {
+                    "name": "backend/output/123/top_5_code_table.csv",
+                    "url": "/api/v2/releases/file/WXC18BDMBTM0M",
+                },
+            ]
+        },
+    )
+
+
+@pytest.fixture
+def fetch_file(responses):
+    responses.add(
+        method="GET",
+        url=urljoin(jobserver.JOB_SERVER_URL, "/api/v2/releases/file/6STFP07F15EM"),
+        body=b"abc123",
+    )
+    responses.add(
+        method="GET",
+        url=urljoin(jobserver.JOB_SERVER_URL, "/api/v2/releases/file/EK8NRG9A6GKQGJ"),
+        body=b'"Patient count"\n"1000"',
+    )
+    responses.add(
+        method="GET",
+        url=urljoin(jobserver.JOB_SERVER_URL, "/api/v2/releases/file/WXC18BDMBTM0M"),
+        body=b'"Code","Proportion of codes (%)"\n "72313002","90.23"',
+    )
+
+
+def test_fetch_release_returns_correct_files(fetch_release, fetch_file):
+    analysis_request_id = "123"
+
+    output = jobserver.fetch_release(analysis_request_id)
+
+    assert "deciles_chart" in output
+    assert "summary" in output
+    assert "Patient count" in output["summary"][0]
+    assert "common_codes" in output
+    assert "Proportion" in output["common_codes"][0]
+    assert "90.23" in output["common_codes"][0]["Proportion"]
+
+
+def test_fetch_release_raises_http_error_on_endpoint_exception(responses):
+    analysis_request_id = "123"
+    responses.add(
+        method="GET",
+        url=jobserver.RELEASES_URL,
+        status=500,
+    )
+
+    with pytest.raises(requests.HTTPError):
+        jobserver.fetch_release(analysis_request_id)

--- a/tests/unit/services/test_jobserver.py
+++ b/tests/unit/services/test_jobserver.py
@@ -75,9 +75,6 @@ def test_fetch_release_returns_correct_files(
 def test_fetch_release_handles_missing_column_for_common_codes(
     fetch_release, fetch_deciles_chart, fetch_event_counts, responses
 ):
-    responses.remove(
-        url=urljoin(jobserver.JOB_SERVER_URL, "/api/v2/releases/file/WXC18BDMBTM0M")
-    )
     responses.add(
         method="GET",
         url=urljoin(jobserver.JOB_SERVER_URL, "/api/v2/releases/file/WXC18BDMBTM0M"),


### PR DESCRIPTION
This uses the common session pool to retrieve files from the job server.

The content of the files are then displayed on the analysis output report.

This change assumes the files will always be available for display, although it doesn't produce an error if they're not there so the rest of the report can be shown. Issue https://github.com/opensafely-core/interactive.opensafely.org/issues/134 covers the case of files not being available.
