### PR TITLE
consolidate job server urls

### DIFF
--- a/dotenv-sample
+++ b/dotenv-sample
@@ -19,16 +19,14 @@ SENTRY_ENVIRONMENT=
 
 # Slack notifications
 SLACK_BOT_TOKEN=fake_token
-# URL to run jobs manually on job-server, used for the slack notification
-JOB_SERVER_JOBS_URL=https://jobs.opensafely.org/datalab/opensafely-interactive
 
-# Retrieve outputs from job-server
-JOB_SERVER_API=https://jobs.opensafely.org/
+# jobserver config
+JOB_SERVER_URL=https://jobs.opensafely.org/
 JOB_SERVER_TOKEN=fake_token
-JOB_SERVER_WORKSPACE=opensafely-interactive
+JOB_SERVER_WORKSPACE=test-interactive
 
 # git config
 # repo to commit to, defaults to local test repo
 WORKSPACE_REPO=./workspace-repo
 # token for auth
-GITHUB_TOKEN=
+GITHUB_TOKEN=fake_token

--- a/interactive/settings.py
+++ b/interactive/settings.py
@@ -231,13 +231,19 @@ DEFAULT_FROM_EMAIL = "OpenSAFELY Interactive <noreply@mg.interactive.opensafely.
 SERVER_EMAIL = "OpenSAFELY Interactive <noreply@mg.interactive.opensafely.org>"
 
 
-# Application settings
+# Required application settings
+#
+# These should be parsed and validated as early as possible, and putting them
+# here allows us to use django's pre-flight checks as part of out deployment
+# automation.
 
 # repo to commit to
+# in dev, a path to local repo, in prod https link to a remote one
 WORKSPACE_REPO = env.str("WORKSPACE_REPO")
 GITHUB_TOKEN = env.str("GITHUB_TOKEN")
 
-# run jobs page
-JOB_SERVER_JOBS_URL = str(
-    furl(env.str("JOB_SERVER_JOBS_URL")) / env.str("JOB_SERVER_WORKSPACE") / "run-jobs"
-)
+# job server config
+JOB_SERVER_URL = furl(env.str("JOB_SERVER_URL", default="https://jobs.opensafely.org"))
+JOB_SERVER_TOKEN = env.str("JOB_SERVER_TOKEN")
+# workspace to submit jobs to and look for outputs in
+JOB_SERVER_WORKSPACE = env.str("JOB_SERVER_WORKSPACE")

--- a/services/slack.py
+++ b/services/slack.py
@@ -29,7 +29,7 @@ def post(text, channel="interactive-requests"):
 
 def link(url, text=None, is_email=False):
     """Because no one can remember this"""
-    if url.startswith("/"):
+    if isinstance(url, str) and url.startswith("/"):
         base_url = furl(settings.BASE_URL)
         base_url.path = url
         url = base_url.url


### PR DESCRIPTION
Consolidate job-server urls

We previously added JOB_SERVER_URL, but we still had a separate
JOB_SERVER_JOBS_URL separately, so misconfiguration was possible.

This change consolidates all job server urls to use JOB_SERVER_URL as
their base, in tests as well.

Partly because it's used in multiple places, it moves the loading and
validation of the related env vars into settings.py, and makes it
a `furl` object, for easier use.

It converts the slack links to use it, and removes the separately set
JOB_SERVER_JOBS_URL.

To help maintain this behaviour in the future, it refactors the
`services/jobserver.py` to use a common client to provide a single place
to manage urls and handle auth. Similarly in the tests, it adds a more
general `add_jobserver_response` fixture, similar to the
`add_codelists_response`. This ensures the tests are using the same
JOB_SERVER_URL as the application code.

