### PR TITLE
id in action names

### DIFF
--- a/interactive/submit.py
+++ b/interactive/submit.py
@@ -18,7 +18,7 @@ expectations:
 
 actions:
 
-  generate_codelist_report:
+  codelist_report_{ID}:
     run: >
       cohortextractor:latest generate_codelist_report
         --codelist-path=codelist.csv
@@ -27,27 +27,27 @@ actions:
         --output-dir output/{ID}
     outputs:
       moderately_sensitive:
-        table: output/*/counts_per_*.csv
-        list_sizes: output/*/list_sizes.csv
+        table: output/{ID}/counts_per_*.csv
+        list_sizes: output/{ID}/list_sizes.csv
 
-  generate_measures:
+  measures_{ID}:
     run: python:latest python analysis/generate_measures.py output/{ID}
-    needs: [generate_codelist_report]
+    needs: [codelist_report_{ID}]
     outputs:
       moderately_sensitive:
-        measure: output/*/measure_counts_per_week_per_practice.csv
+        measure: output/{ID}/measure_counts_per_week_per_practice.csv
 
-  generate_top_5_table:
+  top_5_table_{ID}:
     run: python:latest python analysis/top_codes_table.py output/{ID}
-    needs: [generate_codelist_report]
+    needs: [codelist_report_{ID}]
     outputs:
       moderately_sensitive:
-        table: output/*/top_5_code_table.csv
+        table: output/{ID}/top_5_code_table.csv
 
-  generate_deciles_charts:
+  deciles_charts_{ID}:
     run: >
       deciles-charts:v0.0.24
-        --input-files output/measure_counts_per_week_per_practice.csv
+        --input-files output/{ID}/measure_counts_per_week_per_practice.csv
         --output-dir output/{ID}
     config:
       show_outer_percentiles: false
@@ -55,10 +55,10 @@ actions:
         output: true
       charts:
         output: true
-    needs: [generate_measures]
+    needs: [measures_{ID}]
     outputs:
       moderately_sensitive:
-        deciles_charts: output/*/deciles_*_*.*
+        deciles_charts: output/{ID}/deciles_*.*
 """
 
 

--- a/tests/unit/test_submit.py
+++ b/tests/unit/test_submit.py
@@ -35,8 +35,14 @@ def test_write_files(tmp_path):
     for name, action in p.actions.items():
         assert output_dir in action.run.args
 
-    assert analysis_request.start_date in p.actions["generate_codelist_report"].run.args
-    assert analysis_request.end_date in p.actions["generate_codelist_report"].run.args
+    assert (
+        analysis_request.start_date
+        in p.actions[f"codelist_report_{analysis_request.id}"].run.args
+    )
+    assert (
+        analysis_request.end_date
+        in p.actions[f"codelist_report_{analysis_request.id}"].run.args
+    )
 
     env = {}
     exec(variables.read_text(), None, env)
@@ -72,10 +78,10 @@ def test_create_analysis_commit(workspace_repo, add_codelist_response):
     )
     p = pipeline.load_pipeline(ps.stdout)
     assert list(p.actions.keys()) == [
-        "generate_codelist_report",
-        "generate_measures",
-        "generate_top_5_table",
-        "generate_deciles_charts",
+        f"codelist_report_{analysis_request.id}",
+        f"measures_{analysis_request.id}",
+        f"top_5_table_{analysis_request.id}",
+        f"deciles_charts_{analysis_request.id}",
     ]
 
     ps = submit.git(


### PR DESCRIPTION
Include analysis id in action names
  
This prevents previous runs from interfering with action history.
    
Also, be explict about output dirs, on a hunch to try fix issue with
deciles chart action

