### PR TITLE
Use the short base62 str format to represent IDs

### DIFF
--- a/interactive/models.py
+++ b/interactive/models.py
@@ -114,7 +114,7 @@ class AnalysisRequest(models.Model):
         return self.user == user or user.is_staff
 
     def get_output_url(self):
-        return reverse("request_analysis_output", kwargs={"pk": self.id.uuid})
+        return reverse("request_analysis_output", kwargs={"pk": self.id})
 
 
 @receiver(post_save, sender=User)

--- a/interactive/urls.py
+++ b/interactive/urls.py
@@ -56,7 +56,7 @@ urlpatterns = [
         name="request_analysis_done",
     ),
     path(
-        "request-analysis/<uuid:pk>/output",
+        "request-analysis/<str:pk>/output",
         views.analysis_request_output,
         name="request_analysis_output",
     ),

--- a/interactive/views.py
+++ b/interactive/views.py
@@ -70,7 +70,7 @@ def analysis_request_output(request, pk):
         raise PermissionDenied
 
     context = {"analysis": analysis_request}
-    if outputs := jobserver.fetch_release(str(analysis_request.id.uuid)):
+    if outputs := jobserver.fetch_release(str(analysis_request.id)):
         context.update(outputs)
 
     return render(

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -176,7 +176,7 @@ def test_analysis_request_output(client, user, monkeypatch):
     analysis_request = AnalysisRequestFactory(user=user)
 
     response = client.get(
-        reverse("request_analysis_output", kwargs={"pk": analysis_request.id.uuid})
+        reverse("request_analysis_output", kwargs={"pk": analysis_request.id})
     )
 
     assert response.status_code == 200
@@ -184,7 +184,7 @@ def test_analysis_request_output(client, user, monkeypatch):
 
 
 def test_analysis_request_output_not_logged_in(client, user):
-    pk = timeflake.random().uuid
+    pk = timeflake.random()
     response = client.get(reverse("request_analysis_output", kwargs={"pk": pk}))
     assert response.status_code == 302
 
@@ -193,7 +193,7 @@ def test_analysis_request_output_not_authorised(client, user):
     client.force_login(user)
     analysis_request = AnalysisRequestFactory()
     response = client.get(
-        reverse("request_analysis_output", kwargs={"pk": analysis_request.id.uuid})
+        reverse("request_analysis_output", kwargs={"pk": analysis_request.id})
     )
     assert response.status_code == 403
 
@@ -205,7 +205,7 @@ def test_analysis_request_output_admin_can_view(client, admin_user, monkeypatch)
     analysis_request = AnalysisRequestFactory()
 
     response = client.get(
-        reverse("request_analysis_output", kwargs={"pk": analysis_request.id.uuid})
+        reverse("request_analysis_output", kwargs={"pk": analysis_request.id})
     )
 
     assert response.status_code == 200


### PR DESCRIPTION
This is consistent with the way we're using IDs in the project.yaml and
therefore in job-server.

Pair: Peter