### PR TITLE
Show codelist name instead of slug

### DIFF
--- a/interactive/templates/interactive/analysis_request_output.html
+++ b/interactive/templates/interactive/analysis_request_output.html
@@ -43,7 +43,7 @@
         <div>
           <dt class="text-slate-600 font-semibold mb-1">Requested codelist</dt>
           <dd>
-            {% include "components/link.html" with href="https://www.opencodelists.org/codelist/"|add:analysis.codelist_slug content=analysis.codelist_slug %}
+            {% include "components/link.html" with href="https://www.opencodelists.org/codelist/"|add:analysis.codelist_slug content=analysis.codelist_name %}
           </dd>
         </div>
         <div>

--- a/interactive/templates/interactive/new_analysis_request.html
+++ b/interactive/templates/interactive/new_analysis_request.html
@@ -19,11 +19,15 @@
 
   <div x-title="codelist-select" x-data="{
       codelist: '',
-      get codelistURL() {
-        return `https://www.opencodelists.org/codelist/${this.codelist}`
+      get selectedCodelist() {
+        var select = document.getElementById('{{ form.codelist_slug.id_for_label }}');
+        return {
+          url: `https://www.opencodelists.org/codelist/${this.codelist}`,
+          text: select.options[select.selectedIndex].text
+        }
       }
     }">
-    {% include "components/form-field-select.html" with id=form.codelist_slug.id_for_label label=form.codelist_slug.label name="codelist_slug" required=True choices=form.codelist_slug.field.choices hint="Codelists are published by OpenSAFELY on OpenCodelists and use the SNOMED CT coding system" x_model="codelist" %}
+    {% include "components/form-field-select.html" with id=form.codelist_slug.id_for_label label="Codelist" name="codelist_slug" required=True choices=form.codelist_slug.field.choices hint="Codelists are published by OpenSAFELY on OpenCodelists and use the SNOMED CT coding system" x_model="codelist" %}
 
     <p
       class="mt-2 p-4 border border-slate-100 border-l-4 border-l-oxford-400 text-slate-900"
@@ -38,8 +42,8 @@
         "
         rel="noopener noreferrer"
         target="_blank"
-        x-bind:href="codelistURL"
-        x-text="codelist"
+        x-bind:href="selectedCodelist.url"
+        x-text="selectedCodelist.text"
         ></a>
     </p>
   </div>


### PR DESCRIPTION
Closes #177 

## Before

<img width="654" alt="CleanShot 2022-05-19 at 12 07 41@2x" src="https://user-images.githubusercontent.com/24863179/169279900-9d89870c-65ed-45c4-8390-d9fdf2184c8e.png">

<img width="784" alt="CleanShot 2022-05-19 at 12 07 57@2x" src="https://user-images.githubusercontent.com/24863179/169279908-9e969b17-9732-4d5f-8ce9-580874048c5f.png">

## After

<img width="649" alt="CleanShot 2022-05-19 at 12 08 36@2x" src="https://user-images.githubusercontent.com/24863179/169279909-c5041c44-b338-4cb0-81be-061337de5f5b.png">