### PR TITLE
Pass password reset url into template

### DIFF
--- a/interactive/templates/emails/welcome_email.html
+++ b/interactive/templates/emails/welcome_email.html
@@ -4,9 +4,7 @@
 <p>
   Please click on the link to finish setting up your account<br />
   {% block reset_link %}
-      <a href="{{ domain }}{% url 'password_reset_confirm' uidb64=uid token=token %}">
-        {{ domain }}{% url 'password_reset_confirm' uidb64=uid token=token %}
-      </a>
+      <a href="{{ url }}">{{ url }}</a>
   {% endblock %}
 </p>
 <p>Once you've setup your account, you'll be able to login to <a href="{{ domain }}">the website</a> and request an analysis by clicking on "Get started".</p>


### PR DESCRIPTION
Passing the full url into the context will make it easier to debug any issues.

Fixes: #105