### PR TITLE
Prevent email showing as sent "on behalf of"

### DIFF
--- a/interactive/emails.py
+++ b/interactive/emails.py
@@ -10,7 +10,7 @@ def send_welcome_email(email, context):
 
     msg = EmailMultiAlternatives(
         subject=subject,
-        from_email="team@opensafely.org",
+        reply_to=("team@opensafely.org",),
         to=[email],
         body=text_body,
     )
@@ -25,7 +25,7 @@ def send_analysis_request_email(email, context):
 
     msg = EmailMultiAlternatives(
         subject=subject,
-        from_email="team@opensafely.org",
+        reply_to=("team@opensafely.org",),
         to=[email],
         body=text_body,
     )


### PR DESCRIPTION
This changes the sender to be consistent with where the email is sent from (the
domain used for this by mailgun is mg.interactive.opensafely.org). So, we set
the reply-to field instead to ensure email responses arrive in the right place.

Fixes: #222