### PR TITLE
Prevent email showing as sent "on behalf of"

### DIFF
--- a/interactive/emails.py
+++ b/interactive/emails.py
@@ -10,6 +10,7 @@ def send_welcome_email(email, context):
 
     msg = EmailMultiAlternatives(
         subject=subject,
+        from_email="no-reply@mg.interactive.opensafely.org",
         reply_to=("team@opensafely.org",),
         to=[email],
         body=text_body,
@@ -25,6 +26,7 @@ def send_analysis_request_email(email, context):
 
     msg = EmailMultiAlternatives(
         subject=subject,
+        from_email="no-reply@mg.interactive.opensafely.org",
         reply_to=("team@opensafely.org",),
         to=[email],
         body=text_body,


### PR DESCRIPTION
This changes the sender to be consistent with where the email is sent from (the
domain used for this by mailgun is mg.interactive.opensafely.org). The reply-to
is set to ensure email responses arrive in the right place.