### PR TITLE
Reduce spamminess of emails

### DIFF
--- a/interactive/emails.py
+++ b/interactive/emails.py
@@ -11,7 +11,6 @@ def send_welcome_email(email, context):
     msg = EmailMultiAlternatives(
         subject=subject,
         from_email="no-reply@mg.interactive.opensafely.org",
-        reply_to=("team@opensafely.org",),
         to=[email],
         body=text_body,
     )
@@ -27,7 +26,6 @@ def send_analysis_request_email(email, context):
     msg = EmailMultiAlternatives(
         subject=subject,
         from_email="no-reply@mg.interactive.opensafely.org",
-        reply_to=("team@opensafely.org",),
         to=[email],
         body=text_body,
     )

--- a/interactive/templates/emails/analysis_done.html
+++ b/interactive/templates/emails/analysis_done.html
@@ -1,12 +1,13 @@
 {% autoescape off %}
 <p>Hi {{ name }},</p>
-<p>Your analysis titled "{{ title }}" using OpenSAFELY interactive has now finished running. You can view the results here:<br/>
+<p>Your analysis titled "{{ title }}" using OpenSAFELY interactive has now finished running. You can view the results at:<br/>
   {% block analysis_link %}
     <a href="{{ url }}">{{ url }}</a>
   {% endblock %}
 </p>
 <p>These results are not publicly accessible and are only viewable when logged into your OpenSAFELY Interactive account. Please do not share these results with anyone. If you would like to share the results, please send an email to <a href="mailto:team@opensafely.org">team@opensafely.org</a>.</p>
-<p>OpenSAFELY Interactive is a new tool in active development. Please let us know your thoughts on how we can improve the service by filling out our feedback form, or simply reply to this email.</p>
 <p>Kind regards,</p>
 <p><a href="mailto:team@opensafely.org">The OpenSAFELY Team</a></p>
+<br/>
+<p>OpenSAFELY Interactive is a new tool in active development. Please let us know your thoughts on how we can improve the service by filling out our <a href="https://docs.google.com/forms/d/e/1FAIpQLScWikDx0UlqbEcnbzZhn5FiBTBHc2LtrfhqmmKwgOuKt4oFTQ/viewform">feedback form</a> or by emailing <a href="mailto:team@opensafely.org">team@opensafely.org</a>. Please note, this email has been sent from an unmonitored mailbox.</p>
 {% endautoescape %}

--- a/interactive/templates/emails/welcome_email.html
+++ b/interactive/templates/emails/welcome_email.html
@@ -12,4 +12,7 @@
 <p>Once your analysis has been run, we will send you an email with instructions on how to view the results.</p>
 <p>From,</p>
 <p><a href="mailto:team@opensafely.org">The OpenSAFELY Team</a></p>
+<br/>
+<p>OpenSAFELY Interactive is a new tool in active development. Please let us know your thoughts on how we can improve the service by filling out our <a href="https://docs.google.com/forms/d/e/1FAIpQLScWikDx0UlqbEcnbzZhn5FiBTBHc2LtrfhqmmKwgOuKt4oFTQ/viewform">feedback form</a> or by emailing <a href="mailto:team@opensafely.org">team@opensafely.org</a>. Please note, this email has been sent from an unmonitored mailbox.</p>
+
 {% endautoescape %}


### PR DESCRIPTION
Recent changes to the from address has caused emails to be marked as spam,
because it now differs from the reply-to.

This change removes the reply-to field and adds some text to the email to let
users know how to contact us, since hitting reply won't work. The word "here"
has also been removed from just before a hyperlink, as that can also increase
our spam rating.

A link to the feedback form has also been included for users receiving html
emails.