### PR TITLE
Reduce spamminess of emails

### DIFF
--- a/interactive/emails.py
+++ b/interactive/emails.py
@@ -10,8 +10,8 @@ def send_welcome_email(email, context):
 
     msg = EmailMultiAlternatives(
         subject=subject,
-        from_email="no-reply@mg.interactive.opensafely.org",
-        reply_to=("team@opensafely.org",),
+        from_email="OpenSAFELY Interactive <no-reply@mg.interactive.opensafely.org>",
+        reply_to=("OpenSAFELY Team <team@opensafely.org>",),
         to=[email],
         body=text_body,
     )
@@ -26,8 +26,8 @@ def send_analysis_request_email(email, context):
 
     msg = EmailMultiAlternatives(
         subject=subject,
-        from_email="no-reply@mg.interactive.opensafely.org",
-        reply_to=("team@opensafely.org",),
+        from_email="OpenSAFELY Interactive <no-reply@mg.interactive.opensafely.org>",
+        reply_to=("OpenSAFELY Team <team@opensafely.org>",),
         to=[email],
         body=text_body,
     )

--- a/interactive/templates/emails/analysis_done.html
+++ b/interactive/templates/emails/analysis_done.html
@@ -1,12 +1,15 @@
 {% autoescape off %}
 <p>Hi {{ name }},</p>
-<p>Your analysis titled "{{ title }}" using OpenSAFELY interactive has now finished running. You can view the results here:<br/>
+<p>Your analysis titled "{{ title }}" using OpenSAFELY interactive has now finished running. You can view the results at:<br/>
   {% block analysis_link %}
     <a href="{{ url }}">{{ url }}</a>
   {% endblock %}
 </p>
 <p>These results are not publicly accessible and are only viewable when logged into your OpenSAFELY Interactive account. Please do not share these results with anyone. If you would like to share the results, please send an email to <a href="mailto:team@opensafely.org">team@opensafely.org</a>.</p>
-<p>OpenSAFELY Interactive is a new tool in active development. Please let us know your thoughts on how we can improve the service by filling out our feedback form, or simply reply to this email.</p>
 <p>Kind regards,</p>
 <p><a href="mailto:team@opensafely.org">The OpenSAFELY Team</a></p>
+<br/>
+<p>OpenSAFELY Interactive is a new tool in active development. Please let us know your thoughts on how we can improve the service by filling out our <a href="https://
+docs.google.com/forms/d/e/1FAIpQLScWikDx0UlqbEcnbzZhn5FiBTBHc2LtrfhqmmKwgOuKt4oFTQ/viewform">feedback form</a> or by emailing <a href="mailto:team@opensafely.org">team
+@opensafely.org</a>.
 {% endautoescape %}

--- a/interactive/templates/emails/welcome_email.html
+++ b/interactive/templates/emails/welcome_email.html
@@ -12,4 +12,8 @@
 <p>Once your analysis has been run, we will send you an email with instructions on how to view the results.</p>
 <p>From,</p>
 <p><a href="mailto:team@opensafely.org">The OpenSAFELY Team</a></p>
+<br/>
+<p>OpenSAFELY Interactive is a new tool in active development. Please let us know your thoughts on how we can improve the service by filling out our <a href="https://
+docs.google.com/forms/d/e/1FAIpQLScWikDx0UlqbEcnbzZhn5FiBTBHc2LtrfhqmmKwgOuKt4oFTQ/viewform">feedback form</a> or by emailing <a href="mailto:team@opensafely.org">team
+@opensafely.org</a>.
 {% endautoescape %}


### PR DESCRIPTION
Recent changes to the from address has caused emails to be marked as spam.

This change improves the display of the from and reply-to addresses. It also
makes some content improvements; the word "here" has also been removed from
just before a hyperlink, as that can also increase our spam rating, and a link
to the feedback form has been included for users receiving html emails.