### PR TITLE
Reinstate workflow cache

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: "16"
-          # cache: "npm"
+          cache: "npm"
 
       - name: Install node_modules
         run: npm ci
@@ -47,8 +47,8 @@ jobs:
       - uses: "actions/setup-python@v3"
         with:
           python-version: "3.10"
-          # cache: "pip"
-          # cache-dependency-path: requirements.*.txt
+          cache: "pip"
+          cache-dependency-path: requirements.*.txt
       - uses: extractions/setup-just@v1
       - name: Check formatting, linting and import sorting
         run: just check
@@ -62,8 +62,8 @@ jobs:
       - uses: "actions/setup-python@v3"
         with:
           python-version: "3.10"
-          # cache: "pip"
-          # cache-dependency-path: requirements.*.txt
+          cache: "pip"
+          cache-dependency-path: requirements.*.txt
       - uses: extractions/setup-just@v1
 
       - name: Retrieve assets


### PR DESCRIPTION
Caching in actions was broken, so it was removed in https://github.com/opensafely-core/interactive.opensafely.org/pull/225 – this will reinstate it.