### PR TITLE
Differentiate between codelists with the same name

### DIFF
--- a/assets/src/scripts/Components/Combobox.jsx
+++ b/assets/src/scripts/Components/Combobox.jsx
@@ -2,6 +2,7 @@ import { SelectorIcon, XIcon } from "@heroicons/react/solid";
 import { useCombobox } from "downshift";
 import { arrayOf, func, shape, string } from "prop-types";
 import { useState } from "react";
+import { classNames } from "./utils";
 
 /**
  * Utilise a reducer to revert the users selection if they
@@ -149,16 +150,18 @@ export function Combobox({
                         item,
                         index,
                         key: item.value,
-                        className: `
-                        ${
-                          selectedItem === item ? "bg-oxford-100 font-bold" : ""
-                        }
-                        ${highlightedIndex === index ? "bg-gray-100" : ""}
-                        relative cursor-pointer select-none py-2 pl-3 pr-9 text-gray-900 hover:bg-gray-100
-                      `,
+                        className: classNames(
+                          selectedItem === item && "bg-oxford-100 font-bold",
+                          highlightedIndex === index && "bg-gray-100",
+                          "flex flex-col relative cursor-pointer select-none py-2 pl-3 pr-9  font-semibold text-oxford-600 hover:bg-gray-100"
+                        ),
                       })}
                     >
                       {item.label}
+                      <span className="sr-only">,{" "}</span>
+                      <span className="text-xs text-gray-600 font-normal">
+                        {item.value.split("/")[0].toString()}
+                      </span>
                     </li>
                   ))}
                 </>

--- a/assets/src/scripts/Components/utils.js
+++ b/assets/src/scripts/Components/utils.js
@@ -1,0 +1,3 @@
+export function classNames(...classes) {
+  return classes.filter(Boolean).join(" ");
+}

--- a/assets/src/scripts/__tests__/dropdown.test.jsx
+++ b/assets/src/scripts/__tests__/dropdown.test.jsx
@@ -9,6 +9,7 @@ const props = {
     {
       label: "Abdominal aortic aneurysm diagnosis codes",
       value: "nhsd-primary-care-domain-refsets/aaa_cod/20210127",
+      splitValue: "nhsd-primary-care-domain-refsets",
     },
     {
       label: "Active and inactive ethnicity codes",
@@ -69,14 +70,18 @@ describe("Native <select> component", () => {
     expect(screen.getAllByRole("option").length).toBe(2);
     await user.clear(screen.getByRole("textbox"));
     await user.type(screen.getByRole("textbox"), props.choices[1].label);
-    expect(screen.getByRole("option").textContent).toBe(props.choices[1].label);
+    expect(screen.getByRole("option").textContent).toBe(
+      `${props.choices[1].label}, ${props.choices[1].splitValue}`
+    );
   });
 
   test("Selected item gets a highlighted class", async () => {
     const { container } = render(<Select {...props} />);
 
     await user.type(screen.getByRole("textbox"), props.choices[1].label);
-    expect(screen.getByRole("option").textContent).toBe(props.choices[1].label);
+    expect(screen.getByRole("option").textContent).toBe(
+      `${props.choices[1].label}, ${props.choices[1].splitValue}`
+    );
 
     await user.click(screen.getByRole("option"));
 
@@ -90,7 +95,7 @@ describe("Native <select> component", () => {
     await user.type(screen.getByRole("textbox"), "{Backspace}");
     await waitFor(() =>
       expect(screen.getByRole("option").textContent).toBe(
-        props.choices[1].label
+        `${props.choices[1].label}, ${props.choices[1].splitValue}`
       )
     );
     expect(container.querySelector('[role="option"]')).toHaveClass(
@@ -102,7 +107,9 @@ describe("Native <select> component", () => {
     render(<Select {...props} />);
 
     await user.type(screen.getByRole("textbox"), props.choices[1].label);
-    expect(screen.getByRole("option").textContent).toBe(props.choices[1].label);
+    expect(screen.getByRole("option").textContent).toBe(
+      `${props.choices[1].label}, ${props.choices[1].splitValue}`
+    );
 
     await user.click(screen.getByRole("option"));
 
@@ -123,7 +130,9 @@ describe("Native <select> component", () => {
     render(<Select {...props} />);
 
     await user.type(screen.getByRole("textbox"), props.choices[1].label);
-    expect(screen.getByRole("option").textContent).toBe(props.choices[1].label);
+    expect(screen.getByRole("option").textContent).toBe(
+      `${props.choices[1].label}, ${props.choices[1].splitValue}`
+    );
     await user.click(screen.getByRole("option"));
 
     await user.type(


### PR DESCRIPTION
So that users can correctly identify the codelist they want to use, when two codelists have the same name.

## Before

<img width="545" alt="CleanShot 2022-06-13 at 15 52 23@2x" src="https://user-images.githubusercontent.com/24863179/173381890-0ee629ee-9673-4f5f-bd15-48064e3554f1.png">

## After

<img width="548" alt="CleanShot 2022-06-13 at 15 52 03@2x" src="https://user-images.githubusercontent.com/24863179/173381874-565e54db-9610-4d95-8935-ea8716ed00b5.png">
