### PR TITLE
fix git commit ordering

### DIFF
--- a/interactive/submit.py
+++ b/interactive/submit.py
@@ -171,12 +171,12 @@ def commit_and_push(checkout, analysis_request):
     commit_sha = ps.stdout.strip()
     # this is an super important step, makes it much easier to track commits
     git("tag", str(analysis_request.id), cwd=checkout)
-    # push the tag
-    git("push", "origin", str(analysis_request.id), cwd=checkout)
     # push to master. Note: we technically wouldn't need this from a pure git
     # pov, as a tag would be enough, but job-runner explicitly checks that
     # a commit is on the branch history, for security reasons
     git("push", "origin", "--force-with-lease", cwd=checkout)
+    # push the tag once we know the main push has succeeded
+    git("push", "origin", str(analysis_request.id), cwd=checkout)
     return commit_sha
 
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -17,7 +17,7 @@ class AnalysisRequestFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = AnalysisRequest
 
-    id = timeflake.random()  # noqa: A003
+    id = factory.LazyAttribute(lambda _: timeflake.random())  # noqa: A003
     user = factory.SubFactory("tests.factories.UserFactory")
     title = factory.Sequence(lambda n: f"Analysis Request {n}")
     start_date = factory.Faker("date")


### PR DESCRIPTION
- fix: only push git tag once main push has succeeded
