### PR TITLE
Update text as count is for 4 weeks

### DIFF
--- a/interactive/templates/interactive/analysis_request_output.html
+++ b/interactive/templates/interactive/analysis_request_output.html
@@ -92,7 +92,7 @@
                   </tr>
                   <tr class="divide-x divide-slate-200">
                     <th scope="row" class="whitespace-nowrap px-4 py-3.5 text-left font-semibold text-slate-900">
-                      Events in latest week
+                      Events in latest 4 weeks
                     </th>
                     <td class="whitespace-nowrap w-full p-4 text-slate-700 font-mono">
                       {{ summary.1.count|intcomma }}


### PR DESCRIPTION
This used to show the total number of events in the latest week, but as events
are now grouped by four weeks, this shows the total for the latest four weeks
of data.