### PR TITLE
Create an issue for output checkers and notify them in slack

### DIFF
--- a/interactive/notifications.py
+++ b/interactive/notifications.py
@@ -4,7 +4,7 @@ from furl import furl
 from services import slack
 
 
-def notify_analysis_request_submitted(analysis_request):
+def notify_analysis_request_submitted(analysis_request, issue_url):
     codelist_url = (
         settings.OPENCODELISTS_URL / "codelist" / analysis_request.codelist_slug
     )
@@ -22,13 +22,17 @@ def notify_analysis_request_submitted(analysis_request):
     analysis_url = furl(settings.BASE_URL) / analysis_request.get_output_url()
     analysis_link = slack.link(analysis_url, "here")
 
+    issue_link = slack.link(issue_url, "tracked here")
+
     message = f"{analysis_request.created_by} submitted an analysis request called *{analysis_request.title}*\n"
     message += f"Using codelist: {codelist_link}\n"
     message += f"Commit: {commit_link}\n"
     message += f"A job has been {job_request_url}\n"
+    message += f"Output checking request {issue_link}\n"
     message += f"When complete, the output will be viewable {analysis_link}"
 
     slack.post(text=message)
+    slack.post(text=message, channel="opensafely-outputs")
 
 
 def notify_registration_request_submitted(full_name, job_title, organisation, email):

--- a/interactive/submit.py
+++ b/interactive/submit.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from django.conf import settings
 
 from interactive.notifications import notify_analysis_request_submitted
-from services import jobserver, opencodelists
+from services import github, jobserver, opencodelists
 
 
 PROJECT_YAML = """
@@ -193,4 +193,6 @@ def submit_analysis(analysis_request):
     analysis_request.job_request_url = url
     analysis_request.save(update_fields=["job_request_url"])
 
-    notify_analysis_request_submitted(analysis_request)
+    issue_url = github.create_issue(analysis_request.id, job_server_url=url)
+
+    notify_analysis_request_submitted(analysis_request, issue_url)

--- a/services/github.py
+++ b/services/github.py
@@ -1,0 +1,55 @@
+import requests
+from environs import Env
+from furl import furl
+
+
+env = Env()
+
+
+BASE_URL = "https://api.github.com"
+GITHUB_TOKEN = env.str("GITHUB_TOKEN")
+
+
+session = requests.Session()
+session.headers = {
+    "Accept": "application/vnd.github.v3+json",
+    "Authorization": f"bearer {GITHUB_TOKEN}",
+    "User-Agent": "OpenSAFELY Interactive",
+}
+
+
+def create_issue(analysis_request_id, job_server_url):
+    body = f"""
+    Workspace: {job_server_url}
+
+    The below outputs are located in `output/{analysis_request_id}`
+    - [ ] event_counts.csv
+    - [ ] deciles_chart_counts_per_week_per_practice.png
+    - [ ] top_5_code_table.csv
+    - [ ] practice_count.csv
+
+    The number of practices plotted in the deciles chart is shown in `practice_count.csv`. Check that a sufficient number of practices are included.
+
+    The total number of events, total number of patients and the number of events within the last time period are in `event_counts.csv`. Check that these do not contain any values <=5.
+
+    The unredacted counts underlying `top_5_code_table.csv` can be found in `counts_per_code.csv` . Check that no code with a count <=5 in `counts_per_code.csv` is included in `top_5_code_table.csv`.
+    """
+
+    f = furl(BASE_URL)
+    f.path.segments += [
+        "repos",
+        "ebmdatalab",
+        "opensafely-output-review",
+        "issues",
+    ]
+
+    data = {
+        "title": str(analysis_request_id),
+        "body": body,
+        "labels": ["interactive"],
+    }
+
+    r = session.post(f.url, json=data)
+    r.raise_for_status()
+
+    return r.json()["html_url"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ from .factories import UserFactory
 # include some fixtures from submodules
 # it might be better to move to a tests.fixtures module at some point
 pytest_plugins = [
+    "tests.unit.services.test_github",
     "tests.unit.services.test_jobserver",
     "tests.unit.services.test_opencodelists",
     "tests.unit.test_submit",

--- a/tests/unit/services/test_github.py
+++ b/tests/unit/services/test_github.py
@@ -1,0 +1,31 @@
+import pytest
+from furl import furl
+
+from services import github
+
+
+@pytest.fixture
+def add_github_response(responses):
+    def add(path, method="GET", **kwargs):
+        responses.add(
+            url=str(furl(github.BASE_URL) / path),  # convert furl to str
+            method=method,
+            **kwargs,
+        )
+
+    return add
+
+
+@pytest.fixture
+def create_output_checker_issue(add_github_response):
+    add_github_response(
+        "repos/ebmdatalab/opensafely-output-review/issues",
+        method="POST",
+        json={"html_url": "http://example.com/"},
+    )
+
+
+def test_create_issue(create_output_checker_issue):
+    output = github.create_issue("abc123", "")
+
+    assert output == "http://example.com/"

--- a/tests/unit/test_notifications.py
+++ b/tests/unit/test_notifications.py
@@ -5,7 +5,7 @@ from tests.factories import AnalysisRequestFactory
 def test_notify_analysis_request_submitted(slack_messages):
     analysis_request = AnalysisRequestFactory()
 
-    notifications.notify_analysis_request_submitted(analysis_request)
+    notifications.notify_analysis_request_submitted(analysis_request, "ticket link")
 
     msg = slack_messages[-1].text
     assert analysis_request.user.email in msg
@@ -14,6 +14,7 @@ def test_notify_analysis_request_submitted(slack_messages):
     assert analysis_request.title in msg
     assert str(analysis_request.id) in msg
     assert analysis_request.job_request_url in msg
+    assert "ticket link" in msg
 
 
 def test_notify_register_interest_submitted(slack_messages):

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -121,6 +121,7 @@ def test_new_analysis_request_post_success(
     codelists,
     add_codelist_response,
     submit_job_request,
+    create_output_checker_issue,
     workspace_repo,
 ):
     client.force_login(user)
@@ -146,8 +147,12 @@ def test_new_analysis_request_post_success(
     assert request.job_request_url == "test-url"
     assert str(request.start_date) == "2019-09-01"
     assert str(request.end_date) == date_of_last_extract().strftime("%Y-%m-%d")
-    assert user.email in slack_messages[-1].text
-    assert "opensafely/systolic-blood-pressure-qof/v1" in slack_messages[-1].text
+
+    assert len(slack_messages) == 2
+    analysis_msg, output_msg = slack_messages
+
+    assert user.email in analysis_msg.text
+    assert "opensafely/systolic-blood-pressure-qof/v1" in analysis_msg.text
 
 
 def test_new_analysis_request_post_failure_returns_unsaved_form(


### PR DESCRIPTION
This adds a GitHub module to create an issue in the output checker's repo, using the template we have for OSI outputs there.  It then notifies the `#opensafely-outputs` channel so they know the ticket has been raised.

Fixes #253 

ToDo: work out which scope(s) we need to use the Issues API