### PR TITLE
Remove creation of issues until token is sorted out

### DIFF
--- a/interactive/notifications.py
+++ b/interactive/notifications.py
@@ -4,7 +4,7 @@ from furl import furl
 from services import slack
 
 
-def notify_analysis_request_submitted(analysis_request, issue_url):
+def notify_analysis_request_submitted(analysis_request):
     codelist_url = (
         settings.OPENCODELISTS_URL / "codelist" / analysis_request.codelist_slug
     )
@@ -22,13 +22,10 @@ def notify_analysis_request_submitted(analysis_request, issue_url):
     analysis_url = furl(settings.BASE_URL) / analysis_request.get_output_url()
     analysis_link = slack.link(analysis_url, "here")
 
-    issue_link = slack.link(issue_url, "tracked here")
-
     message = f"{analysis_request.created_by} submitted an analysis request called *{analysis_request.title}*\n"
     message += f"Using codelist: {codelist_link}\n"
     message += f"Commit: {commit_link}\n"
     message += f"A job has been {job_request_url}\n"
-    message += f"Output checking request {issue_link}\n"
     message += f"When complete, the output will be viewable {analysis_link}"
 
     slack.post(text=message)

--- a/interactive/submit.py
+++ b/interactive/submit.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from django.conf import settings
 
 from interactive.notifications import notify_analysis_request_submitted
-from services import github, jobserver, opencodelists
+from services import jobserver, opencodelists
 
 
 PROJECT_YAML = """
@@ -193,6 +193,4 @@ def submit_analysis(analysis_request):
     analysis_request.job_request_url = url
     analysis_request.save(update_fields=["job_request_url"])
 
-    issue_url = github.create_issue(analysis_request.id, job_server_url=url)
-
-    notify_analysis_request_submitted(analysis_request, issue_url)
+    notify_analysis_request_submitted(analysis_request)

--- a/tests/unit/test_notifications.py
+++ b/tests/unit/test_notifications.py
@@ -5,7 +5,7 @@ from tests.factories import AnalysisRequestFactory
 def test_notify_analysis_request_submitted(slack_messages):
     analysis_request = AnalysisRequestFactory()
 
-    notifications.notify_analysis_request_submitted(analysis_request, "ticket link")
+    notifications.notify_analysis_request_submitted(analysis_request)
 
     msg = slack_messages[-1].text
     assert analysis_request.user.email in msg
@@ -14,7 +14,6 @@ def test_notify_analysis_request_submitted(slack_messages):
     assert analysis_request.title in msg
     assert str(analysis_request.id) in msg
     assert analysis_request.job_request_url in msg
-    assert "ticket link" in msg
 
 
 def test_notify_register_interest_submitted(slack_messages):

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -121,7 +121,6 @@ def test_new_analysis_request_post_success(
     codelists,
     add_codelist_response,
     submit_job_request,
-    create_output_checker_issue,
     workspace_repo,
 ):
     client.force_login(user)


### PR DESCRIPTION
We currently don't have a method for OSI to write to GitHub and these
changes were accidentally merged while we were working out that method.
This removes the write portions, while we work things out, in a single
commit so they can be easily reverted.