### PR TITLE
Remove second slack message until GitHub issues fixed

### DIFF
--- a/interactive/notifications.py
+++ b/interactive/notifications.py
@@ -29,7 +29,6 @@ def notify_analysis_request_submitted(analysis_request):
     message += f"When complete, the output will be viewable {analysis_link}"
 
     slack.post(text=message)
-    slack.post(text=message, channel="opensafely-outputs")
 
 
 def notify_registration_request_submitted(full_name, job_title, organisation, email):

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -147,8 +147,8 @@ def test_new_analysis_request_post_success(
     assert str(request.start_date) == "2019-09-01"
     assert str(request.end_date) == date_of_last_extract().strftime("%Y-%m-%d")
 
-    assert len(slack_messages) == 2
-    analysis_msg, output_msg = slack_messages
+    assert len(slack_messages) == 1
+    analysis_msg = slack_messages[0]
 
     assert user.email in analysis_msg.text
     assert "opensafely/systolic-blood-pressure-qof/v1" in analysis_msg.text


### PR DESCRIPTION
The automatic creation of a GitHub issue was removed in an earlier commit, but
the slack notification was left in. This change removes that until the GitHub
issue creation is restored.