### PR TITLE
Revert Removal of Issue Creation

### DIFF
--- a/interactive/notifications.py
+++ b/interactive/notifications.py
@@ -4,7 +4,7 @@ from furl import furl
 from services import slack
 
 
-def notify_analysis_request_submitted(analysis_request):
+def notify_analysis_request_submitted(analysis_request, issue_url):
     codelist_url = (
         settings.OPENCODELISTS_URL / "codelist" / analysis_request.codelist_slug
     )
@@ -22,10 +22,13 @@ def notify_analysis_request_submitted(analysis_request):
     analysis_url = furl(settings.BASE_URL) / analysis_request.get_output_url()
     analysis_link = slack.link(analysis_url, "here")
 
+    issue_link = slack.link(issue_url, "tracked here")
+
     message = f"{analysis_request.created_by} submitted an analysis request called *{analysis_request.title}*\n"
     message += f"Using codelist: {codelist_link}\n"
     message += f"Commit: {commit_link}\n"
     message += f"A job has been {job_request_url}\n"
+    message += f"Output checking request {issue_link}\n"
     message += f"When complete, the output will be viewable {analysis_link}"
 
     slack.post(text=message)

--- a/interactive/notifications.py
+++ b/interactive/notifications.py
@@ -32,6 +32,7 @@ def notify_analysis_request_submitted(analysis_request, issue_url):
     message += f"When complete, the output will be viewable {analysis_link}"
 
     slack.post(text=message)
+    slack.post(text=message, channel="opensafely-outputs")
 
 
 def notify_registration_request_submitted(full_name, job_title, organisation, email):

--- a/interactive/submit.py
+++ b/interactive/submit.py
@@ -8,7 +8,7 @@ from django.conf import settings
 
 from interactive.notifications import notify_analysis_request_submitted
 from reports.codelist import write_files
-from services import jobserver, opencodelists
+from services import github, jobserver, opencodelists
 
 from .emails import send_analysis_request_confirmation_email
 
@@ -114,7 +114,8 @@ def submit_analysis(analysis_request, force=False):
     analysis_request.job_request_url = url
     analysis_request.save(update_fields=["job_request_url"])
 
-    notify_analysis_request_submitted(analysis_request)
+    issue_url = github.create_issue(analysis_request.id, job_server_url=url)
+    notify_analysis_request_submitted(analysis_request, issue_url)
 
     send_analysis_request_confirmation_email(
         analysis_request.user.email,

--- a/services/github.py
+++ b/services/github.py
@@ -38,8 +38,8 @@ def create_issue(analysis_request_id, job_server_url):
     f = furl(BASE_URL)
     f.path.segments += [
         "repos",
-        "ebmdatalab",
-        "opensafely-output-review",
+        "opensafely",
+        "interactive",
         "issues",
     ]
 

--- a/tests/unit/management/commands/test_resubmit.py
+++ b/tests/unit/management/commands/test_resubmit.py
@@ -21,7 +21,11 @@ def test_resubmit_error():
 
 
 def test_resubmit_success(
-    workspace_repo, add_codelist_response, slack_messages, submit_job_request
+    workspace_repo,
+    add_codelist_response,
+    slack_messages,
+    submit_job_request,
+    create_output_checker_issue,
 ):
     analysis_request = AnalysisRequestFactory()
     add_codelist_response(analysis_request.codelist_slug, "1\n2\n3")

--- a/tests/unit/services/test_github.py
+++ b/tests/unit/services/test_github.py
@@ -19,7 +19,7 @@ def add_github_response(responses):
 @pytest.fixture
 def create_output_checker_issue(add_github_response):
     add_github_response(
-        "repos/ebmdatalab/opensafely-output-review/issues",
+        "repos/opensafely/interactive/issues",
         method="POST",
         json={"html_url": "http://example.com/"},
     )

--- a/tests/unit/test_notifications.py
+++ b/tests/unit/test_notifications.py
@@ -5,7 +5,7 @@ from tests.factories import AnalysisRequestFactory
 def test_notify_analysis_request_submitted(slack_messages):
     analysis_request = AnalysisRequestFactory()
 
-    notifications.notify_analysis_request_submitted(analysis_request)
+    notifications.notify_analysis_request_submitted(analysis_request, "ticket link")
 
     msg = slack_messages[-1].text
     assert analysis_request.user.email in msg
@@ -14,6 +14,7 @@ def test_notify_analysis_request_submitted(slack_messages):
     assert analysis_request.title in msg
     assert str(analysis_request.id) in msg
     assert analysis_request.job_request_url in msg
+    assert "ticket link" in msg
 
 
 def test_notify_register_interest_submitted(slack_messages):

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -121,6 +121,7 @@ def test_new_analysis_request_post_success(
     codelists,
     add_codelist_response,
     submit_job_request,
+    create_output_checker_issue,
     workspace_repo,
 ):
     client.force_login(user)

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -148,8 +148,8 @@ def test_new_analysis_request_post_success(
     assert str(request.start_date) == "2019-09-01"
     assert str(request.end_date) == date_of_last_extract().strftime("%Y-%m-%d")
 
-    assert len(slack_messages) == 1
-    analysis_msg = slack_messages[0]
+    assert len(slack_messages) == 2
+    analysis_msg, output_msg = slack_messages
 
     assert user.email in analysis_msg.text
     assert "opensafely/systolic-blood-pressure-qof/v1" in analysis_msg.text


### PR DESCRIPTION
This reinstates the ability to create issues on GitHub for output checkers.

Currently blocked on switching the OSI GitHub token.

Fixes #253 