### PR TITLE
Turn numpy array into a list

### DIFF
--- a/tests/reports/test_codelist.py
+++ b/tests/reports/test_codelist.py
@@ -289,7 +289,7 @@ def test_group_low_values(df, threshold):
     suppressed_count = result.loc[result[code_column] == "Other", count_column].values
     assert len(suppressed_count) <= 1
     if len(suppressed_count) == 1:  # pragma: no cover
-        assert suppressed_count.to_list()[0] >= threshold
+        assert suppressed_count.tolist()[0] >= threshold
 
 
 @st.composite


### PR DESCRIPTION
We're now returning back a numpy array to assert upon, so need to change how we
reference it.