### PR TITLE
Ignore updates to analytics dependancies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,9 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 20
+    ignore:
+      - dependency-name: "pandas"
+      - dependency-name: "numpy"
 
   - package-ecosystem: "npm"
     directory: "/"


### PR DESCRIPTION
Dependencies for the analytics code need to match the version specified in the
python docker image that'll be used to run the code in production. This means
it should be updated manually, when the docker image is updated, and not by
dependabot.