### PR TITLE
Skip the whole job if js dependabot update

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -2,9 +2,6 @@ name: Approve and enable auto-merge for Dependabot updates
 
 on:
   pull_request:
-    branches:
-      - 'dependabot/github_actions/**'
-      - 'dependabot/pip/**'
 
 permissions:
   pull-requests: write
@@ -13,7 +10,7 @@ permissions:
 jobs:
   dependabot:
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' }}
+    if: ${{ github.actor == 'dependabot[bot]' && !contains(github.head_ref, 'npm_and_yarn') }}
     steps:
       - name: Dependabot metadata
         id: metadata


### PR DESCRIPTION
The pull_request -> branches block is for the target branch, not source branch,
so isn't useful in our case. Similarly, ref_name in the case of a pull_request
looks at main. So we need to use head_ref to get the source branch of the pull
request.