### PR TITLE
Use TemplateResponses

### DIFF
--- a/interactive/views.py
+++ b/interactive/views.py
@@ -4,7 +4,8 @@ from django.contrib.auth.decorators import login_required
 from django.contrib.auth.views import LoginView as DjangoLoginView
 from django.contrib.auth.views import LogoutView as DjangoLogoutView
 from django.core.exceptions import PermissionDenied
-from django.shortcuts import get_object_or_404, redirect, render
+from django.shortcuts import get_object_or_404, redirect
+from django.template.response import TemplateResponse
 from django.utils import timezone
 from furl import furl
 
@@ -18,11 +19,11 @@ from .notifications import notify_registration_request_submitted
 
 
 def index(request):
-    return render(request, "index.html")
+    return TemplateResponse(request, "index.html")
 
 
 def about(request):
-    return render(request, "about.html")
+    return TemplateResponse(request, "about.html")
 
 
 def register_interest(request):
@@ -39,11 +40,13 @@ def register_interest(request):
             return redirect("register_interest_done")
     else:
         form = RegistrationRequestForm()
-    return render(request, "interactive/register_interest.html", {"form": form})
+    return TemplateResponse(
+        request, "interactive/register_interest.html", {"form": form}
+    )
 
 
 def register_interest_done(request):
-    return render(request, "interactive/register_interest_done.html")
+    return TemplateResponse(request, "interactive/register_interest_done.html")
 
 
 @login_required
@@ -81,12 +84,12 @@ def new_analysis_request(request):
         "end_date": END_DATE,
         "codelists": codelists,
     }
-    return render(request, "interactive/new_analysis_request.html", ctx)
+    return TemplateResponse(request, "interactive/new_analysis_request.html", ctx)
 
 
 @login_required
 def new_analysis_request_done(request):
-    return render(request, "interactive/new_analysis_request_done.html")
+    return TemplateResponse(request, "interactive/new_analysis_request_done.html")
 
 
 @login_required
@@ -99,7 +102,7 @@ def analysis_request_output(request, pk):
     if outputs := jobserver.fetch_release(str(analysis_request.id)):
         context.update(outputs)
 
-    return render(
+    return TemplateResponse(
         request,
         "interactive/analysis_request_output.html",
         context,
@@ -149,7 +152,7 @@ class LogoutView(DjangoLogoutView):
 # Error pages
 #
 def bad_request(request, exception=None):
-    return render(
+    return TemplateResponse(
         request,
         "error.html",
         status=400,
@@ -162,7 +165,7 @@ def bad_request(request, exception=None):
 
 
 def permission_denied(request, exception=None):
-    return render(
+    return TemplateResponse(
         request,
         "error.html",
         status=403,
@@ -175,7 +178,7 @@ def permission_denied(request, exception=None):
 
 
 def page_not_found(request, exception=None):
-    return render(
+    return TemplateResponse(
         request,
         "error.html",
         status=404,
@@ -188,7 +191,7 @@ def page_not_found(request, exception=None):
 
 
 def server_error(request):
-    return render(
+    return TemplateResponse(
         request,
         "error.html",
         status=500,
@@ -201,7 +204,7 @@ def server_error(request):
 
 
 def csrf_failure(request, reason=""):
-    return render(
+    return TemplateResponse(
         request,
         "error.html",
         status=400,

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -1,6 +1,5 @@
 import timeflake
 from django.contrib.messages import get_messages
-from django.test.client import RequestFactory
 from django.urls import reverse
 
 from interactive import views
@@ -282,33 +281,29 @@ def test_analysis_request_email_user_not_logged_in(client):
     assert response.url.startswith("/login")
 
 
-def test_bad_request():
-    factory = RequestFactory()
-    request = factory.get("/")
+def test_bad_request(rf):
+    request = rf.get("/")
     response = views.bad_request(request)
     assert response.status_code == 400
     assert "Bad request" in response.rendered_content
 
 
-def test_permission_denied():
-    factory = RequestFactory()
-    request = factory.get("/")
+def test_permission_denied(rf):
+    request = rf.get("/")
     response = views.permission_denied(request)
     assert response.status_code == 403
     assert "Permission denied" in response.rendered_content
 
 
-def test_page_not_found():
-    factory = RequestFactory()
-    request = factory.get("/")
+def test_page_not_found(rf):
+    request = rf.get("/")
     response = views.page_not_found(request)
     assert response.status_code == 404
     assert "Page not found" in response.rendered_content
 
 
-def test_server_error():
-    factory = RequestFactory()
-    request = factory.get("/")
+def test_server_error(rf):
+    request = rf.get("/")
     response = views.server_error(request)
     assert response.status_code == 500
     assert "Server error" in response.rendered_content

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -287,7 +287,7 @@ def test_bad_request():
     request = factory.get("/")
     response = views.bad_request(request)
     assert response.status_code == 400
-    assert b"Bad request" in response.content
+    assert "Bad request" in response.rendered_content
 
 
 def test_permission_denied():
@@ -295,7 +295,7 @@ def test_permission_denied():
     request = factory.get("/")
     response = views.permission_denied(request)
     assert response.status_code == 403
-    assert b"Permission denied" in response.content
+    assert "Permission denied" in response.rendered_content
 
 
 def test_page_not_found():
@@ -303,7 +303,7 @@ def test_page_not_found():
     request = factory.get("/")
     response = views.page_not_found(request)
     assert response.status_code == 404
-    assert b"Page not found" in response.content
+    assert "Page not found" in response.rendered_content
 
 
 def test_server_error():
@@ -311,14 +311,14 @@ def test_server_error():
     request = factory.get("/")
     response = views.server_error(request)
     assert response.status_code == 500
-    assert b"Server error" in response.content
+    assert "Server error" in response.rendered_content
 
 
 def test_csrf_failure(client):
     client.handler.enforce_csrf_checks = True
     response = client.post(reverse("home"), {})
     assert response.status_code == 400
-    assert b"CSRF Failed" in response.content
+    assert "CSRF Failed" in response.rendered_content
 
 
 def assert_logged_in(client, user):


### PR DESCRIPTION
Some housekeeping to use a response type (TemplateResponse instead of HttpResponse) which aids in debugging responses, and a quick drive by to use the `rf` fixture.