### PR TITLE
Convert emails to incuna-mail

### DIFF
--- a/interactive/emails.py
+++ b/interactive/emails.py
@@ -41,20 +41,23 @@ def send_analysis_request_email(email, analysis_request):
         context=context,
     )
 
-def send_analysis_request_confirmation_email(to, subject, context):
-    subject = f"OpenSAFELY: {subject} submitted"
-    html_body = render_to_string("emails/analysis_confirmation.html", context)
-    text_body = _convert_html(html_body)
 
-    msg = EmailMultiAlternatives(
-        subject=subject,
-        from_email="OpenSAFELY Interactive <no-reply@mg.interactive.opensafely.org>",
-        reply_to=("OpenSAFELY Team <team@opensafely.org>",),
-        to=[to],
-        body=text_body,
+def send_analysis_request_confirmation_email(email, analysis_request):
+    context = {
+        "name": analysis_request.user.name,
+        "codelist": analysis_request.codelist_name,
+        "email": analysis_request.user.email,
+    }
+
+    send(
+        to=email,
+        subject=f"OpenSAFELY: {analysis_request.title} submitted",
+        sender="OpenSAFELY Interactive <no-reply@mg.interactive.opensafely.org>",
+        reply_to=["OpenSAFELY Team <team@opensafely.org>"],
+        template_name="emails/analysis_confirmation.txt",
+        html_template_name="emails/analysis_confirmation.html",
+        context=context,
     )
-    msg.attach_alternative(html_body, "text/html")
-    msg.send()
 
 
 def _convert_html(raw_html):

--- a/interactive/settings.py
+++ b/interactive/settings.py
@@ -214,9 +214,6 @@ CSRF_FAILURE_VIEW = "interactive.views.csrf_failure"
 CSRF_TRUSTED_ORIGINS = [BASE_URL]
 SESSION_COOKIE_SECURE = not DEBUG
 
-EMAIL_BACKEND = "django.core.mail.backends.filebased.EmailBackend"
-EMAIL_FILE_PATH = BASE_DIR / "sent_emails"
-
 # THIRD PARTY SETTINGS
 
 sentry.initialise_sentry()

--- a/interactive/submit.py
+++ b/interactive/submit.py
@@ -118,13 +118,7 @@ def submit_analysis(analysis_request, force=False):
     notify_analysis_request_submitted(analysis_request, issue_url)
 
     send_analysis_request_confirmation_email(
-        analysis_request.user.email,
-        subject=analysis_request.title,
-        context={
-            "name": analysis_request.user.name,
-            "codelist": analysis_request.codelist_name,
-            "email": analysis_request.user.email,
-        },
+        analysis_request.user.email, analysis_request
     )
 
 

--- a/interactive/templates/emails/analysis_confirmation.txt
+++ b/interactive/templates/emails/analysis_confirmation.txt
@@ -1,0 +1,13 @@
+{% extends "emails/base.txt" %}
+
+{% block content %}
+Hi {{ name }},
+
+You submitted an analysis request for the {{ codelist }} codelist.
+
+We will send an email to {{ email }} when your analysis is ready.
+
+During the pilot phase results will be checked carefully by our team for privacy and security reasons.
+We aim to process requests within half a working day, although it may take up to two working days.
+We are working to improve and automate these processes in the future.
+{% endblock %}

--- a/interactive/templates/emails/analysis_done.txt
+++ b/interactive/templates/emails/analysis_done.txt
@@ -1,0 +1,11 @@
+{% extends "emails/base.txt" %}
+
+{% block content %}
+Hi {{ name }},
+
+Your analysis titled "{{ title }}" using OpenSAFELY interactive has now finished running. You can view the results at:
+
+{{ url }}
+
+These results are not publicly accessible and are only viewable when logged into your OpenSAFELY Interactive account. Please do not share these results with anyone. If you would like to share the results, please send an email to us at team@opensafely.org
+{% endblock %}

--- a/interactive/templates/emails/base.txt
+++ b/interactive/templates/emails/base.txt
@@ -1,0 +1,9 @@
+{% block content %}{% endblock %}
+Kind regards,
+The OpenSAFELY Team
+
+OpenSAFELY Interactive is a new tool in active development. Please let us know your thoughts on how we can improve the service by filling out our feedback form:
+
+https://docs.google.com/forms/d/e/1FAIpQLScWikDx0UlqbEcnbzZhn5FiBTBHc2LtrfhqmmKwgOuKt4oFTQ/viewform
+
+or by emailing us at: team@opensafely.org

--- a/interactive/templates/emails/welcome_email.txt
+++ b/interactive/templates/emails/welcome_email.txt
@@ -1,0 +1,17 @@
+{% extends "emails/base.txt" %}
+
+{% block content %}
+Hi {{ name }},
+
+Thank you for your interest in OpenSAFELY Interactive.
+
+Please click on the link to finish setting up your account:
+
+{{ url }}
+
+Once you've setup your account, you'll be able to login to the website, {{ domain }}, and request an analysis by clicking on "Get started".
+
+In the early development phase, you will be able to analyse the rate of recorded coding activity in primary care across a specified time period, using all SNOMED CT codelists that have been used in OpenSAFELY projects for covid-related purposes.
+
+Once your analysis has been run, we will send you an email with instructions on how to view the results.
+{% endblock %}

--- a/interactive/views.py
+++ b/interactive/views.py
@@ -1,4 +1,3 @@
-from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.views import LoginView as DjangoLoginView
@@ -8,7 +7,6 @@ from django.shortcuts import get_object_or_404, redirect
 from django.template.response import TemplateResponse
 from django.utils import timezone
 from django.views.generic import FormView
-from furl import furl
 
 from interactive.submit import submit_analysis
 from services import jobserver, opencodelists
@@ -100,12 +98,7 @@ def analysis_request_email(request, pk):
         return permission_denied(request)
 
     analysis_request = get_object_or_404(AnalysisRequest, pk=pk)
-    context = {
-        "name": analysis_request.user.name,
-        "title": analysis_request.title,
-        "url": furl(settings.BASE_URL) / analysis_request.get_output_url(),
-    }
-    send_analysis_request_email(analysis_request.user.email, context)
+    send_analysis_request_email(analysis_request.user.email, analysis_request)
 
     analysis_request.complete_email_sent_at = timezone.now()
     analysis_request.save()

--- a/requirements.prod.in
+++ b/requirements.prod.in
@@ -11,7 +11,6 @@ django-vite
 environs[django]
 furl
 gunicorn
-html2text
 incuna-mail
 psycopg2-binary
 requests

--- a/requirements.prod.in
+++ b/requirements.prod.in
@@ -12,6 +12,7 @@ environs[django]
 furl
 gunicorn
 html2text
+incuna-mail
 psycopg2-binary
 requests
 sentry-sdk

--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -136,10 +136,6 @@ gunicorn==20.1.0 \
     --hash=sha256:9dcc4547dbb1cb284accfb15ab5667a0e5d1881cc443e0677b4882a4067a807e \
     --hash=sha256:e0a968b5ba15f8a328fdfd7ab1fcb5af4470c28aaf7e55df02a99bc13138e6e8
     # via -r requirements.prod.in
-html2text==2020.1.16 \
-    --hash=sha256:c7c629882da0cf377d66f073329ccf34a12ed2adf0169b9285ae4e63ef54c82b \
-    --hash=sha256:e296318e16b059ddb97f7a8a1d6a5c1d7af4544049a01e261731d2d5cc277bbb
-    # via -r requirements.prod.in
 idna==3.3 \
     --hash=sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff \
     --hash=sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d

--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -144,6 +144,10 @@ idna==3.3 \
     --hash=sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff \
     --hash=sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d
     # via requests
+incuna-mail==4.1.1 \
+    --hash=sha256:4071949a7cc70f88c1acea5f06ac8ba439029f655ff5d8c98277bbc8cc8d4bd5 \
+    --hash=sha256:d8ef4979264fba729fa1478819d71f66af17a795e82d9607d8e7ccd7edaafe10
+    # via -r requirements.prod.in
 marshmallow==3.15.0 \
     --hash=sha256:2aaaab4f01ef4f5a011a21319af9fce17ab13bf28a026d1252adab0e035648d5 \
     --hash=sha256:ff79885ed43b579782f48c251d262e062bce49c65c52412458769a4fb57ac30f
@@ -250,6 +254,7 @@ six==1.16.0 \
     --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
     # via
     #   furl
+    #   incuna-mail
     #   orderedmultidict
 slack-sdk==3.19.3 \
     --hash=sha256:316574ffaf0f5c55bd08476b0a34f3bd2caa9b90b814859bc22922f25934d3aa \

--- a/tests/unit/test_emails.py
+++ b/tests/unit/test_emails.py
@@ -1,0 +1,87 @@
+from django.conf import settings
+from django.contrib.auth.tokens import PasswordResetTokenGenerator
+from django.utils.encoding import force_bytes
+from django.utils.http import urlsafe_base64_encode
+from furl import furl
+
+from interactive.emails import (
+    send_analysis_request_confirmation_email,
+    send_analysis_request_email,
+    send_welcome_email,
+)
+
+from ..factories import AnalysisRequestFactory, UserFactory
+
+
+def test_send_welcome_email(mailoutbox):
+    user = UserFactory()
+
+    uid = urlsafe_base64_encode(force_bytes(user.pk))
+    token = PasswordResetTokenGenerator().make_token(user)
+    reset_url = furl(settings.BASE_URL) / user.get_password_reset_url(uid, token)
+
+    context = {
+        "name": user.name,
+        "url": reset_url,
+    }
+    send_welcome_email(user.email, context)
+
+    m = mailoutbox[0]
+
+    assert list(m.to) == [user.email]
+
+    assert m.subject == "Welcome to OpenSAFELY Interactive"
+
+    assert settings.BASE_URL in m.body
+    assert user.name in m.body
+    assert "password-reset" in m.body, m.body
+
+
+def test_send_analysis_request_email(mailoutbox):
+    user = UserFactory()
+    analysis_request = AnalysisRequestFactory(user=user)
+
+    context = {
+        "name": user.name,
+        "title": analysis_request.title,
+        "url": furl(settings.BASE_URL) / analysis_request.get_output_url(),
+    }
+    send_analysis_request_email(user.email, context)
+
+    # reference the last email because creating a user creates one too
+    # TODO: remove the signal creating this email
+    m = mailoutbox[-1]
+
+    assert list(m.to) == [user.email]
+
+    assert m.subject == f"OpenSAFELY: {analysis_request.title}"
+
+    assert analysis_request.get_output_url() in m.body
+    assert user.name in m.body
+
+
+def test_send_analysis_request_confirmation_email(mailoutbox):
+    user = UserFactory()
+    analysis_request = AnalysisRequestFactory(user=user)
+
+    context = {
+        "name": user.name,
+        "codelist": analysis_request.codelist_name,
+        "email": user.email,
+    }
+
+    send_analysis_request_confirmation_email(
+        user.email, analysis_request.title, context
+    )
+
+    # reference the last email because creating a user creates one too
+    # TODO: remove the signal creating this email
+    m = mailoutbox[-1]
+
+    assert list(m.to) == [user.email]
+
+    assert m.subject == f"OpenSAFELY: {analysis_request.title} submitted"
+
+    assert analysis_request.codelist_name in m.body
+    assert user.name in m.body
+    assert user.email in m.body

--- a/tests/unit/test_emails.py
+++ b/tests/unit/test_emails.py
@@ -59,15 +59,7 @@ def test_send_analysis_request_confirmation_email(mailoutbox):
     user = UserFactory()
     analysis_request = AnalysisRequestFactory(user=user)
 
-    context = {
-        "name": user.name,
-        "codelist": analysis_request.codelist_name,
-        "email": user.email,
-    }
-
-    send_analysis_request_confirmation_email(
-        user.email, analysis_request.title, context
-    )
+    send_analysis_request_confirmation_email(user.email, analysis_request)
 
     # reference the last email because creating a user creates one too
     # TODO: remove the signal creating this email

--- a/tests/unit/test_emails.py
+++ b/tests/unit/test_emails.py
@@ -41,12 +41,7 @@ def test_send_analysis_request_email(mailoutbox):
     user = UserFactory()
     analysis_request = AnalysisRequestFactory(user=user)
 
-    context = {
-        "name": user.name,
-        "title": analysis_request.title,
-        "url": furl(settings.BASE_URL) / analysis_request.get_output_url(),
-    }
-    send_analysis_request_email(user.email, context)
+    send_analysis_request_email(user.email, analysis_request)
 
     # reference the last email because creating a user creates one too
     # TODO: remove the signal creating this email

--- a/tests/unit/test_emails.py
+++ b/tests/unit/test_emails.py
@@ -1,8 +1,4 @@
 from django.conf import settings
-from django.contrib.auth.tokens import PasswordResetTokenGenerator
-from django.utils.encoding import force_bytes
-from django.utils.http import urlsafe_base64_encode
-from furl import furl
 
 from interactive.emails import (
     send_analysis_request_confirmation_email,
@@ -16,15 +12,7 @@ from ..factories import AnalysisRequestFactory, UserFactory
 def test_send_welcome_email(mailoutbox):
     user = UserFactory()
 
-    uid = urlsafe_base64_encode(force_bytes(user.pk))
-    token = PasswordResetTokenGenerator().make_token(user)
-    reset_url = furl(settings.BASE_URL) / user.get_password_reset_url(uid, token)
-
-    context = {
-        "name": user.name,
-        "url": reset_url,
-    }
-    send_welcome_email(user.email, context)
+    send_welcome_email(user.email, user)
 
     m = mailoutbox[0]
 


### PR DESCRIPTION
This switches us over to using incuna-mail, a higher level interface for dual mimetype emails, with useful defaults.

This is useful for two reasons:
* it avoids misconfigurations of EmailMultiAlternatives (eg `to` requires a list of addresses)
* it wraps the rendering of two separate templates so we can have both a text and HTML template stack, allowing us to format both appropriately for their respecitive mediums.