### PR TITLE
Move from ubuntu 20.04 to 22.04 LTS

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   dependabot:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: ${{ github.actor == 'dependabot[bot]' && !contains(github.head_ref, 'npm_and_yarn') }}
     steps:
       - name: Dependabot metadata

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   assets:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v3
@@ -40,7 +40,7 @@ jobs:
           path: assets/dist/bundle
 
   check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v3
@@ -55,7 +55,7 @@ jobs:
 
   test:
     needs: [assets, check]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v3
@@ -80,7 +80,7 @@ jobs:
           just test --hypothesis-profile ci
 
   lint-dockerfile:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: hadolint/hadolint-action@v3.0.0
@@ -89,7 +89,7 @@ jobs:
           failure-threshold: error
 
   docker-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v3
@@ -104,7 +104,7 @@ jobs:
 
   deploy:
     needs: [check, test, docker-test, lint-dockerfile]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     concurrency: deploy-production
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,15 +95,27 @@ jobs:
       - uses: actions/checkout@v3
       - uses: extractions/setup-just@95b912dc5d3ed106a72907f2f9b91e76d60bdb76  # v1.5.0
 
-      - name: Build docker image and run tests in it
+      - name: Run unit tests on docker dev image
         run: |
           # build docker and run test
           just docker-test --hypothesis-profile ci
+
+  docker-smoke-test:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: extractions/setup-just@95b912dc5d3ed106a72907f2f9b91e76d60bdb76  # v1.5.0
+
+      - name: Run smoke test on prod image
+        run: |
           # test the prod image builds, as its slightly different, and has caught us out before.
-          just docker-build prod
+          just docker-serve prod -d
+          sleep 5
+          just docker-smoke-test || { docker logs docker_prod_1; exit 1; }
 
   deploy:
-    needs: [check, test, docker-test, lint-dockerfile]
+    needs: [check, test, docker-test, lint-dockerfile, docker-smoke-test]
     runs-on: ubuntu-22.04
 
     concurrency: deploy-production

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,19 +7,11 @@
 # the latest base image, by design.
 #
 # hadolint ignore=DL3007
-FROM ghcr.io/opensafely-core/base-docker:latest as base-python
+FROM ghcr.io/opensafely-core/base-docker:22.04 as base-python
 
 # we are going to use an apt cache on the host, so disable the default debian
 # docker clean up that deletes that cache on every apt install
 RUN rm -f /etc/apt/apt.conf.d/docker-clean
-
-# ensure fully working base python3.10 installation using deadsnakes ppa
-# see: https://gist.github.com/tiran/2dec9e03c6f901814f6d1e8dad09528e
-# use space efficient utility from base image
-RUN --mount=type=cache,target=/var/cache/apt \
-    echo "deb http://ppa.launchpad.net/deadsnakes/ppa/ubuntu focal main" > /etc/apt/sources.list.d/deadsnakes-ppa.list &&\
-    /usr/lib/apt/apt-helper download-file 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xf23c5a6cf475977595c89f51ba6932366a755776' /etc/apt/trusted.gpg.d/deadsnakes.asc &&\
-    root/docker-apt-install.sh python3.10 python3.10-venv python3.10-distutils tzdata ca-certificates
 
 # install any additional system dependencies
 COPY docker/dependencies.txt /tmp/dependencies.txt

--- a/docker/dependencies.txt
+++ b/docker/dependencies.txt
@@ -1,3 +1,7 @@
 # list ubuntu packages needed in production, one per line
-postgresql-client
 git
+postgresql-client
+python3.10
+python3.10-distutils
+python3.10-venv
+tzdata

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -33,8 +33,15 @@ services:
         - GITREF
     # use dockers builitin PID daemon
     init: true
+    # used when running the image in CI/locally
+    env_file:
+      - ../.env
+    environment:
+      - DEBUG=0
+      # override db hostname, so we can reach it within the container
+      - DATABASE_URL=postgres://user:pass@db:5432/interactive
     ports:
-      - "8000:8000"
+      - "8000:5000"
 
   node-assets:
     extends:

--- a/docker/justfile
+++ b/docker/justfile
@@ -34,17 +34,24 @@ test *args="": copy-assets
 
 
 # run dev server in docker container
-serve: copy-assets
+serve env="dev" *options="": copy-assets
     docker-compose up --detach db
-    docker-compose up dev
+    docker-compose up {{ options }} {{ env }}
 
 
-# run command in dev container
-run *args="bash": copy-assets
+# run command in container
+run env="dev" *args="bash": copy-assets
     docker-compose up --detach db
-    docker-compose run dev {{ args }}
+    docker-compose run {{ env }} {{ args }}
 
 
-# exec command in existing dev container
-exec *args="bash": copy-assets
-    docker-compose exec dev {{ args }}
+# exec command in existing container
+exec env="dev" *args="bash": copy-assets
+    docker-compose exec {{ env }} {{ args }}
+
+
+# run a basic functional smoke test against a running container
+smoke-test host="http://localhost:8000":
+    #!/bin/bash
+    set -eu
+    curl -I {{ host }} -s --compressed --fail --retry 20 --retry-delay 1 --retry-all-errors

--- a/justfile
+++ b/justfile
@@ -170,8 +170,8 @@ docker-test *args="": _env
     {{ just_executable() }} docker/test {{ args }}
 
 # run dev server in docker container
-docker-serve: _env
-    {{ just_executable() }} docker/serve
+docker-serve env="dev" *options="": _env
+    {{ just_executable() }} docker/serve {{ env }} {{ options }}
 
 # run cmd in dev docker continer
 docker-run *args="bash": _env
@@ -180,3 +180,7 @@ docker-run *args="bash": _env
 # exec command in an existing dev docker container
 docker-exec *args="bash": _env
     {{ just_executable() }} docker/exec {{ args }}
+
+# run basic smoke test against a running docker container
+docker-smoke-test host="http://localhost:8000": _env
+    {{ just_executable() }} docker/smoke-test {{ host }}


### PR DESCRIPTION
This also updates the GHAs to use an explict version of ubuntu, so we can control when we upgrade and to keep it in line with our Dockerfile.

Fixes https://github.com/opensafely-core/interactive.opensafely.org/issues/431