### PR TITLE
Django admin option to make selected users inactive

### DIFF
--- a/interactive/admin.py
+++ b/interactive/admin.py
@@ -10,14 +10,26 @@ from interactive.models import AnalysisRequest, RegistrationRequest, User
 
 @admin.register(User)
 class UserAdmin(admin.ModelAdmin):
-    fields = ["email", "name", "job_title", "organisation", "is_staff"]
-    list_display = ["email", "name", "is_staff", "job_title", "organisation"]
+    fields = ["email", "name", "job_title", "organisation", "is_staff", "is_active"]
+    list_display = [
+        "email",
+        "name",
+        "is_staff",
+        "is_active",
+        "job_title",
+        "organisation",
+    ]
     search_fields = ["email", "name", "job_title", "organisation"]
-    list_filter = ["is_staff", "organisation"]
+    list_filter = ["is_staff", "is_active", "organisation"]
     readonly_fields = ["email"]
+    actions = ["make_inactive"]
 
     def has_add_permission(self, request):
         return False
+
+    @admin.action
+    def make_inactive(self, request, queryset):
+        queryset.update(is_active=False)
 
 
 # Remove standard admin

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -1,11 +1,25 @@
 from datetime import datetime, timezone
 
+from django.contrib.admin.sites import AdminSite
 from django.contrib.messages import get_messages
 from django.urls import reverse
 
+from interactive.admin import UserAdmin
 from interactive.models import RegistrationRequest, User
 
-from ..factories import RegistrationRequestFactory
+from ..factories import RegistrationRequestFactory, UserFactory
+
+
+def test_admin_make_inactive_makes_users_inactive(client, admin_user):
+    client.force_login(admin_user)
+
+    UserFactory()
+    user_admin = UserAdmin(User, AdminSite())
+    queryset = User.objects.all()
+
+    user_admin.make_inactive(None, queryset)
+
+    assert User.objects.filter(is_active=True).count() == 0
 
 
 def test_registration_request_response_change_loads_successfully(client, admin_user):


### PR DESCRIPTION
We need to disable (and then probably delete) user accounts now that version 1 of OSI is being wrapped up and replaced. This allows us to do it quickly and in a way that's potentially reversable.